### PR TITLE
[mb2] Do not fail if qtc_ macros are missing from spec

### DIFF
--- a/sdk-setup/src/mb2
+++ b/sdk-setup/src/mb2
@@ -92,14 +92,18 @@ usage() {
 EOF
 }
 
+notice() {
+    echo "NOTICE: $*"
+}
+
 fatal() {
     echo "Fatal: $*"
     exit 1
 }
 
-assert_spec_supports_mb2() {
+check_spec_supports_qtc() {
     if ! grep "define qtc_qmake" "$spec" >/dev/null 2>&1 ; then
-	fatal "This specfile does not have the qtc_* macros defined"
+	notice "This specfile does not have the qtc_* macros defined"
     fi
 }
 
@@ -448,7 +452,7 @@ case "$1" in
     qmake | make | install | rpm | deploy )
 	cmd=run_$1
 	if [[ "$spec" ]]; then
-	    assert_spec_supports_mb2
+	    check_spec_supports_qtc
 	fi
         shift
         ;;


### PR DESCRIPTION
Downgraded failure to just a notification. The user can have a
perfectly fine spec file that works without the qtc_ macros,
so it does not make sense to fail the build in that case.

Signed-off-by: Juha Kallioinen juha.kallioinen@jolla.com
