### PR TITLE
[mer-bash-setup] Force POSIX locale settings

### DIFF
--- a/sdk-setup/src/mer-bash-setup
+++ b/sdk-setup/src/mer-bash-setup
@@ -12,3 +12,11 @@ fi
 
 [[ -e ~/.mersdk.profile ]] && . ~/.mersdk.profile
 
+if [[ $(locale |cut -d= -f2 |tr -d "'\"" |sort -u |sed '/^$/d') != POSIX ]]; then
+   echo "$0: Warning: Forcing POSIX locale settings" >&2
+   for var in $(locale |cut -d= -f1); do
+       if eval [[ \$$var ]]; then
+          export $var=
+       fi
+   done
+fi


### PR DESCRIPTION
It is not desired to inherit locale settings from host environment since
the only locales provided within the SDK are C and POSIX.  The latter is
the default when no locale is explicitly selected.